### PR TITLE
Fix ElvUI scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.0.4] - 2019-06-24
+### Fixed
+- ElvUI changes the global UI scale in an invasive way to get pixel-perfect frames. Added code to prevent ElvUI from resizing the width of DetailsHorison's main background frame.
+- Fix dependencies (Details is named "Details", not "Details! Damage Meter).
+
 ## [0.0.3] - 2019-06-23
 ### Added
 - FiraCode-Medium font and license

--- a/DetailsHorizon.toc
+++ b/DetailsHorizon.toc
@@ -1,9 +1,9 @@
 ## Interface: 80100
 ## Title: DetailsHorizon
 ## Notes: Horizontal display of Details data.
-## Version: 0.0.3
+## Version: 0.0.4
 ## Author: Exac
-## OptionalDeps: Ace3, LibSharedMedia-3.0, Details! Damage Meter
+## OptionalDeps: Ace3, LibSharedMedia-3.0, Details
 ## SavedVariables: DetailsHorizonDB
 ## SavedVariablesPerCharacter: DetailsHorizonPerCharDB
 


### PR DESCRIPTION
ElvUI changes the global UI scale in an invasive way to get pixel-perfect frames. Added code to prevent ElvUI from resizing the width of DetailsHorison's main background frame.

Fix dependencies (Details is named 'Details', not 'Details! Damage Meter').