### PR TITLE
Fix width, required deps, default font, and attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.0.5] - 2019-06-24
+### Changed
+- The default font is not Arial Narrow, and it is no longer initially incorrect because it's path was being stored instead of teh name of the font.
+### Fixed
+- Bars were not taking up the correct amount of the screen's width after 0.0.4 introduced a bug
+- Details! is now a Required Dependency so new users are not greeted by a blank addon.
+- Changed profile.addribute and profile.subattribute's default value to a number (in case the addon is ever initially loaded without Details!).
+
 ## [0.0.4] - 2019-06-24
 ### Fixed
 - ElvUI changes the global UI scale in an invasive way to get pixel-perfect frames. Added code to prevent ElvUI from resizing the width of DetailsHorison's main background frame.

--- a/DetailsHorizon.lua
+++ b/DetailsHorizon.lua
@@ -25,8 +25,8 @@ local LibSharedMedia = LibStub("LibSharedMedia-3.0")
 -- Database defaults
 local defaults = {
     profile = {
-        attribute = DETAILS_ATTRIBUTE_DAMAGE,
-        subattribute = DETAILS_SUBATTRIBUTE_DPS,
+        attribute = 1,
+        subattribute = 1,
         background = {
             alignment = "BOTTOM", -- TOP | BOTTOM | CENTER
             color = {
@@ -66,12 +66,12 @@ local defaults = {
                     blue = 1.0,
                     alpha = 1.0
                 },
-                innerPadding = 5,
+                innerPadding = 12,
                 size = 16,
-                font = "Fonts\\FRIZQT__.TTF",
+                font = "Arial Narrow",
                 style = "OUTLINE, MONOCHROME", -- "OUTLINE, MONOCHROME"
                 shadow = 1,
-                justifyH = "CENTER", -- CENTER, LEFT, RIGHT
+                justifyH = "LEFT", -- CENTER, LEFT, RIGHT
                 truncate = true,
                 fmt = "%n [%t]" -- %n=name, %t=total, %s=total/time
             },
@@ -311,10 +311,13 @@ function DetailsHorizon:StyleParentFrame()
     DetailsHorizon:Update(DetailsHorizon:GenerateData())
 end
 
--- Set width of frame to 100%
+-- Set width of frame to 100%. Returns the width of the screen.
 function DetailsHorizon:SetFrameParentMaxWidth()
-    frameParent:SetWidth( DetailsHorizon:GetRealScreenWidth() )
+    local w = DetailsHorizon:GetRealScreenWidth()
+    frameParent:SetWidth( w )
     frameParent:SetScale( DetailsHorizon:Scale(1) )
+
+    return w
 end
 
 -- Is the Details addon loaded?
@@ -375,14 +378,13 @@ function DetailsHorizon:Update(data)
     -- The ElvUI addon interfers with the ui scale that we're using, so every
     -- time we update, we need to update the  size of the frame. This is
     -- costly, so if we can fix this, we should.
-    DetailsHorizon:SetFrameParentMaxWidth()
+    local width = DetailsHorizon:SetFrameParentMaxWidth()
 
     -- Local variables
     local isRelative = self.db.profile.switches.isRelative
     local isCustomColor = self.db.profile.bars.isCustomColor
     local isTextUsingClassColor = self.db.profile.switches.isTextUsingClassColor
     local height = self.db.profile.background.height * 1 / UIParent:GetEffectiveScale()
-    local width = GetScreenWidth() -- Width of screen
     local padding = self.db.profile.bars.padding * UIParent:GetEffectiveScale() -- Horizontal padding
     local fmt = self.db.profile.bars.text.fmt
     -- Every child frame

--- a/DetailsHorizon.toc
+++ b/DetailsHorizon.toc
@@ -1,9 +1,10 @@
 ## Interface: 80100
 ## Title: DetailsHorizon
 ## Notes: Horizontal display of Details data.
-## Version: 0.0.4
+## Version: 0.0.5
 ## Author: Exac
-## OptionalDeps: Ace3, LibSharedMedia-3.0, Details
+## OptionalDeps: Ace3, LibSharedMedia-3.0
+## RequiredDeps: Details
 ## SavedVariables: DetailsHorizonDB
 ## SavedVariablesPerCharacter: DetailsHorizonPerCharDB
 


### PR DESCRIPTION
- default font changed to Arial Narrow

- fixed Bars were not taking up the correct amount of the screen's width after 0.0.4 introduced a bug

- Fixed Details! is now a Required Dependency so new users are not greeted by a blank addon.

- Changed profile.addribute and profile.subattribute's default value to a number (in case the addon is ever initially loaded without Details!).