### PR TITLE
Add check for frame existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.0.10] - 2019-07-02
+### Changed
+- Add checks to the code to make sure the frames have been created before using them.
+
 ## [0.0.9] - 2019-06-25
 ### Fixed
 - Fixed a bug where the width of the main bar was not expanding to the edge of the screen because other addons were changing the UI Scale on initialization.

--- a/DetailsHorizon.lua
+++ b/DetailsHorizon.lua
@@ -178,10 +178,13 @@ end
 
 -- Do all the styling for the child frames
 function DetailsHorizon:StyleChildFrames()
-    -- First, move all children off-screen incase the
+    -- First, move all children off-screen in case the
     -- childframe count has been decreased we don't
     -- want old frames sitting around.
     for _, c in ipairs(frameParent.children) do
+        -- Break out of for loop if child is nil
+        if type( c ) == "nil" then break end
+
         c:ClearAllPoints()
         c:SetWidth(0)
         c:SetHeight(0)

--- a/DetailsHorizon.toc
+++ b/DetailsHorizon.toc
@@ -1,7 +1,7 @@
 ## Interface: 80200
 ## Title: DetailsHorizon
 ## Notes: Horizontal display of Details data.
-## Version: 0.0.9
+## Version: 0.0.10
 ## Author: Exac
 ## OptionalDeps: Ace3, LibSharedMedia-3.0
 ## RequiredDeps: Details


### PR DESCRIPTION
- Ensure frames exist before calling SetWidth() and SetPoint()
- This ensures that in edge-cases, errors do not appear if the frame isn't ready to be manipulated yet.